### PR TITLE
Support multi dimension output layer

### DIFF
--- a/lib/menoh.rb
+++ b/lib/menoh.rb
@@ -23,11 +23,11 @@ module Menoh
   end
 end
 
-def transpose(buffer, shape)
+def reshape(buffer, shape)
   sliced_buffer = buffer.each_slice(buffer.length / shape[0]).to_a
   if shape.length > 2
     next_shape = shape.slice(1, shape.length)
-    sliced_buffer = sliced_buffer.map { |buf| transpose buf, next_shape }
+    sliced_buffer = sliced_buffer.map { |buf| reshape buf, next_shape }
   end
   sliced_buffer
 end
@@ -77,7 +77,7 @@ module Menoh
       results.map do |raw|
         buffer = raw[:data]
         shape = raw[:shape]
-        raw[:data] = transpose buffer, shape
+        raw[:data] = reshape buffer, shape
       end
 
       yield results if block_given?

--- a/lib/menoh.rb
+++ b/lib/menoh.rb
@@ -26,7 +26,7 @@ end
 def transpose(buffer, shape)
   sliced_buffer = buffer.each_slice(buffer.length / shape[0]).to_a
   if shape.length > 2
-    next_shape = shape.slice(1, a.length)
+    next_shape = shape.slice(1, shape.length)
     sliced_buffer = sliced_buffer.map { |buf| transpose buf, next_shape }
   end
   sliced_buffer

--- a/test/menoh_test.rb
+++ b/test/menoh_test.rb
@@ -298,17 +298,17 @@ class MenohTest < Minitest::Test
   end
 
   def test_reshape
-    assert_equal([[0], [1], [2], [3]], reshape([0, 1, 2, 3], [4, 1]))
-    assert_equal([[0, 1], [2, 3]], reshape([0, 1, 2, 3], [2, 2]))
-    assert_equal([[0, 1, 2, 3]], reshape([0, 1, 2, 3], [1, 4]))
-    assert_equal([[[0, 1], [2, 3]]], reshape([0, 1, 2, 3], [1, 2, 2]))
+    assert_equal([[0], [1], [2], [3]], Menoh::Util.reshape([0, 1, 2, 3], [4, 1]))
+    assert_equal([[0, 1], [2, 3]], Menoh::Util.reshape([0, 1, 2, 3], [2, 2]))
+    assert_equal([[0, 1, 2, 3]], Menoh::Util.reshape([0, 1, 2, 3], [1, 4]))
+    assert_equal([[[0, 1], [2, 3]]], Menoh::Util.reshape([0, 1, 2, 3], [1, 2, 2]))
     assert_equal([
                    [
                      [0, 1, 2, 3],
                      [4, 5, 6, 7]
                    ]
                  ],
-                 reshape([0, 1, 2, 3, 4, 5, 6, 7],
+                 Menoh::Util.reshape([0, 1, 2, 3, 4, 5, 6, 7],
                          [1, 2, 4]))
     assert_equal([
                    [
@@ -320,7 +320,7 @@ class MenohTest < Minitest::Test
                      [6, 7]
                    ]
                  ],
-                 reshape([0, 1, 2, 3, 4, 5, 6, 7],
+                 Menoh::Util.reshape([0, 1, 2, 3, 4, 5, 6, 7],
                          [2, 2, 2]))
   end
 end

--- a/test/menoh_test.rb
+++ b/test/menoh_test.rb
@@ -259,7 +259,7 @@ class MenohTest < Minitest::Test
         output_layers: ['invalid']
       }
     ]
-    # TODO test for menoh_variable_profile_table_builder_add_input_profile_dims_2
+    # TODO: test for menoh_variable_profile_table_builder_add_input_profile_dims_2
     etc_opts.each do |opt|
       assert_raises { onnx.make_model(opt) }
     end
@@ -295,5 +295,32 @@ class MenohTest < Minitest::Test
       }
       assert_raises { model.run(imageset) }
     end
+  end
+
+  def test_reshape
+    assert_equal([[0], [1], [2], [3]], reshape([0, 1, 2, 3], [4, 1]))
+    assert_equal([[0, 1], [2, 3]], reshape([0, 1, 2, 3], [2, 2]))
+    assert_equal([[0, 1, 2, 3]], reshape([0, 1, 2, 3], [1, 4]))
+    assert_equal([[[0, 1], [2, 3]]], reshape([0, 1, 2, 3], [1, 2, 2]))
+    assert_equal([
+                   [
+                     [0, 1, 2, 3],
+                     [4, 5, 6, 7]
+                   ]
+                 ],
+                 reshape([0, 1, 2, 3, 4, 5, 6, 7],
+                         [1, 2, 4]))
+    assert_equal([
+                   [
+                     [0, 1],
+                     [2, 3]
+                   ],
+                   [
+                     [4, 5],
+                     [6, 7]
+                   ]
+                 ],
+                 reshape([0, 1, 2, 3, 4, 5, 6, 7],
+                         [2, 2, 2]))
   end
 end


### PR DESCRIPTION
This fix will support ONNX Models which have multi dimension (**_NCHW_**, **_NHW_**, etc.) output layers.
 - fix bug of `transpose` method
 - rename `transpose` method to `reshape`