### PR TITLE
simplify extconf.rb

### DIFF
--- a/ext/menoh_native/extconf.rb
+++ b/ext/menoh_native/extconf.rb
@@ -1,14 +1,7 @@
 require 'mkmf'
 
-# have_library("stdc++")
-have_library('mkldnn')
-have_library('protobuf')
+dir_config('menoh')
 
-menoh_dir = dir_config('menoh')
-$INCFLAGS << " -I#{menoh_dir[0]}/menoh"
-have_library('menoh')
-
-# $CPPFLAGS << " -std=c++14"
-$DLDFLAGS << ' -rdynamic'
-
-create_makefile('menoh/menoh_native')
+if have_header("menoh/menoh.h") and have_library('menoh')
+  create_makefile('menoh/menoh_native')
+end


### PR DESCRIPTION
This PR simplifies `extconf.rb`:

* Stop linking `mkldnn` and `protobuf` because they are only used indirectly through `menoh` library. (if `menoh` is compiled as a shared library (`.so`, `.dylib`, or `dll`), we do not need to link dependencies).
* Remove `-rdynamic` from `$DLDFLAGS` because I don't understand why `-rdynamic` is necessary.
* We don't need to add the results of `dir_config('menoh')` to `$INCFLAGS` since they are alreday added to `$CPPFLAGS` and `$LIBPATH` automatically.