### PR TITLE
Upgrade menoh v1.1.0

### DIFF
--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -76,11 +76,11 @@ static void wrap_model_free(menohModel *p) {
     if (p->model_builder) menoh_delete_model_builder(p->model_builder);
     if (p->input_buffs) {
       for (int32_t i = 0; i < p->input_layer_num; i++) {
-        if (p->input_buffs[i]) ruby_xfree(p->input_buffs[i]);
+        ruby_xfree(p->input_buffs[i]);
       }
-      ruby_xfree(p->input_buffs);
     }
-    if (p->output_buffs) ruby_xfree(p->output_buffs);
+    ruby_xfree(p->input_buffs);
+    ruby_xfree(p->output_buffs);
     ruby_xfree(p);
   }
 }

--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -22,8 +22,8 @@ static menoh_ruby *getONNX(VALUE self) {
 static void wrap_menoh_free(menoh_ruby *p) {
   if (p) {
     if (p->model_data) menoh_delete_model_data(p->model_data);
-    ruby_xfree(p);
   }
+  ruby_xfree(p);
 }
 
 static VALUE wrap_menoh_alloc(VALUE klass) {

--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -128,9 +128,8 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
       NUM2INT(rb_funcall(voutput_layers, rb_intern("length"), 0, NULL));
   for (int32_t i = 0; i < output_layer_num; i++) {
     VALUE voutput_layer = rb_ary_entry(voutput_layers, i);
-    ERROR_CHECK(menoh_variable_profile_table_builder_add_output_profile(
-                    getModel(self)->vpt_builder, StringValueCStr(voutput_layer),
-                    menoh_dtype_float),
+    ERROR_CHECK(menoh_variable_profile_table_builder_add_output_name(
+                    getModel(self)->vpt_builder, StringValueCStr(voutput_layer)),
                 rb_eStandardError);
   }
 

--- a/test/menoh_test.rb
+++ b/test/menoh_test.rb
@@ -227,16 +227,17 @@ class MenohTest < Minitest::Test
 
     etc_opts = [
       ## invalid image size
-      {
-        backend: 'mkldnn',
-        input_layers: [
-          {
-            name: MNIST_IN_NAME,
-            dims: [10, 1, 28, 128]
-          }
-        ],
-        output_layers: [MNIST_OUT_NAME]
-      },
+      # # omit this test because Menoh accepts any size
+      # {
+      #   backend: 'mkldnn',
+      #   input_layers: [
+      #     {
+      #       name: MNIST_IN_NAME,
+      #       dims: [10, 1, 28, 128]
+      #     }
+      #   ],
+      #   output_layers: [MNIST_OUT_NAME]
+      # },
       ## onnx doesn't have name
       {
         backend: 'mkldnn',


### PR DESCRIPTION
removed deprecated functions and replaced substitute functions.
 - replaced `menoh_variable_profile_table_builder_add_input_profile_dims_*` to `menoh_variable_profile_table_builder_add_input_profile`
 - replaced `menoh_variable_profile_table_builder_add_output_profile` to `menoh_variable_profile_table_builder_add_output_name`
