### PR TITLE
fix pointer-to-VALUE conversion warnings caused by incorrect use of rb_funcall

### DIFF
--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -121,7 +121,7 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
 
   // set output_layer
   int32_t output_layer_num =
-      NUM2INT(rb_funcall(voutput_layers, rb_intern("length"), 0, NULL));
+      NUM2INT(rb_funcall(voutput_layers, rb_intern("length"), 0));
   for (int32_t i = 0; i < output_layer_num; i++) {
     VALUE voutput_layer = rb_ary_entry(voutput_layers, i);
     ERROR_CHECK(menoh_variable_profile_table_builder_add_output_profile(
@@ -132,14 +132,14 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
 
   // set input layer
   int32_t input_layer_num =
-      NUM2INT(rb_funcall(vinput_layers, rb_intern("length"), 0, NULL));
+      NUM2INT(rb_funcall(vinput_layers, rb_intern("length"), 0));
   getModel(self)->input_layer_num = input_layer_num;
   for (int32_t i = 0; i < input_layer_num; i++) {
     VALUE vinput_layer = rb_ary_entry(vinput_layers, i);
     VALUE vname = rb_hash_aref(vinput_layer, rb_to_symbol(rb_str_new2("name")));
     VALUE vdims = rb_hash_aref(vinput_layer, rb_to_symbol(rb_str_new2("dims")));
     int32_t dims_length =
-        NUM2INT(rb_funcall(vdims, rb_intern("length"), 0, NULL));
+        NUM2INT(rb_funcall(vdims, rb_intern("length"), 0));
 
     switch (dims_length) {
       case 2:
@@ -193,7 +193,7 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
     VALUE vdims =
         rb_hash_aref(vinput_layer, rb_to_symbol(rb_str_new2("dims")));
     int32_t dims_length =
-        NUM2INT(rb_funcall(vdims, rb_intern("length"), 0, NULL));
+        NUM2INT(rb_funcall(vdims, rb_intern("length"), 0));
 
     // prepare input buffer
     int32_t buffer_length = 1;
@@ -223,9 +223,9 @@ static VALUE wrap_model_run(VALUE self, VALUE dataset) {
   VALUE voutput_layers = getModel(self)->voutput_layers;
 
   int32_t input_layer_num =
-      NUM2INT(rb_funcall(vinput_layers, rb_intern("length"), 0, NULL));
+      NUM2INT(rb_funcall(vinput_layers, rb_intern("length"), 0));
   int32_t output_layer_num =
-      NUM2INT(rb_funcall(voutput_layers, rb_intern("length"), 0, NULL));
+      NUM2INT(rb_funcall(voutput_layers, rb_intern("length"), 0));
 
   // Copy input image data to model's input array
   for (int32_t i = 0; i < input_layer_num; i++) {
@@ -233,7 +233,7 @@ static VALUE wrap_model_run(VALUE self, VALUE dataset) {
     VALUE vname = rb_hash_aref(vinput_layer, rb_to_symbol(rb_str_new2("name")));
     VALUE vdims = rb_hash_aref(vinput_layer, rb_to_symbol(rb_str_new2("dims")));
     int32_t dims_length =
-        NUM2INT(rb_funcall(vdims, rb_intern("length"), 0, NULL));
+        NUM2INT(rb_funcall(vdims, rb_intern("length"), 0));
     int32_t buffer_length = 1;
     for (int32_t j = 0; j < dims_length; j++)
       buffer_length *= NUM2INT(rb_ary_entry(vdims, j));


### PR DESCRIPTION
It fixes warning like the following:
```
../../../../ext/menoh_native/menoh_ruby.c: In function 'wrap_model_init':
../../../../ext/menoh_native/menoh_ruby.c:124:7: warning: initialization of 'long long unsigned int' from 'void *' makes integer from pointer without a cast [-Wint-conversion]
       NUM2INT(rb_funcall(voutput_layers, rb_intern("length"), 0, NULL));
       ^~~~~~~
../../../../ext/menoh_native/menoh_ruby.c:124:7: note: (near initialization for 'rb_funcall_args[0]')
```

`rb_funcall` takes variable number of `VALUE` arguments, so passing a pointer value `NULL` is incorrect.