### PR TITLE
use pkg_config in extconf.rb

### DIFF
--- a/ext/menoh_native/extconf.rb
+++ b/ext/menoh_native/extconf.rb
@@ -1,7 +1,5 @@
 require 'mkmf'
 
-dir_config('menoh')
-
-if have_header("menoh/menoh.h") and have_library('menoh')
+if pkg_config("menoh")
   create_makefile('menoh/menoh_native')
 end


### PR DESCRIPTION
This PR change `extconf.rb` to use `pkg-config` to get options for Menoh library.