### PR TITLE
Reduce fields from menohModel

### DIFF
--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -57,7 +57,6 @@ static VALUE wrap_menoh_init(VALUE self, VALUE vfilename) {
 }
 
 typedef struct menohModel {
-  VALUE vbackend;
   float **input_buffs;
   float **output_buffs;
   menoh_variable_profile_table_builder_handle vpt_builder;
@@ -105,7 +104,6 @@ static void wrap_model_free(menohModel *p) {
 
 static void wrap_model_mark(menohModel *p) {
   if (p) {
-    if (p->vbackend) rb_gc_mark(p->vbackend);
     if (p->vinput_layers) rb_gc_mark(p->vinput_layers);
     if (p->voutput_layers) rb_gc_mark(p->voutput_layers);
   }
@@ -121,7 +119,6 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
   // option
   menoh_model_data_handle model_data = getONNX(vonnx)->model_data;
   VALUE vbackend = rb_hash_aref(option, ID2SYM(id_backend));
-  getModel(self)->vbackend = vbackend;
 
   // option
   VALUE vinput_layers =

--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -57,7 +57,6 @@ static VALUE wrap_menoh_init(VALUE self, VALUE vfilename) {
 }
 
 typedef struct menohModel {
-  menoh_model_data_handle model_data;
   VALUE vbackend;
   float **input_buffs;
   float **output_buffs;
@@ -120,7 +119,7 @@ static VALUE wrap_model_alloc(VALUE klass) {
 
 static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
   // option
-  getModel(self)->model_data = getONNX(vonnx)->model_data;
+  menoh_model_data_handle model_data = getONNX(vonnx)->model_data;
   VALUE vbackend = rb_hash_aref(option, ID2SYM(id_backend));
   getModel(self)->vbackend = vbackend;
 
@@ -174,13 +173,13 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
 
   // build variable provile table
   ERROR_CHECK(menoh_build_variable_profile_table(
-                  getModel(self)->vpt_builder, getModel(self)->model_data,
+                  getModel(self)->vpt_builder, model_data,
                   &(getModel(self)->variable_profile_table)),
               rb_eStandardError);
 
   // optimize
   ERROR_CHECK(
-      menoh_model_data_optimize(getModel(self)->model_data,
+      menoh_model_data_optimize(model_data,
                                 getModel(self)->variable_profile_table),
       rb_eStandardError);
 
@@ -216,7 +215,7 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
 
   // build model
   ERROR_CHECK(menoh_build_model(
-                  getModel(self)->model_builder, getModel(self)->model_data,
+                  getModel(self)->model_builder, model_data,
                   StringValueCStr(vbackend), "", &(getModel(self)->model)),
               rb_eStandardError);
 


### PR DESCRIPTION
This PR removes the following fields from `menohModel` because they are used only during `wrap_model_init`.
* `model_data`
* `vbackend`
* `vpt_builder`
* `model_builder`
