### PR TITLE
set up buffers in Menoh::MenohModel#initialize

### DIFF
--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -282,10 +282,10 @@ static VALUE build_model(VALUE arg) {
   menoh_model_builder_handle model_builder = arg2->model_builder;
 
   // build model
-  menoh_model_handle model;
   ERROR_CHECK(menoh_build_model(
                   model_builder, model_data,
-                  StringValueCStr(vbackend), "", &model));
+                  StringValueCStr(vbackend), "", &getModel(self)->model));
+  menoh_model_handle model = getModel(self)->model;
 
   // attach input buffer to model builder
   int32_t input_layer_num =
@@ -327,7 +327,7 @@ static VALUE build_model(VALUE arg) {
     getModel(self)->output_buffs[i] = output_buff;
   }
 
-  return (VALUE)model;
+  return Qnil;
 }
 
 static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
@@ -378,8 +378,7 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
     .model_data = model_data,
     .model_builder = model_builder
   };
-  getModel(self)->model = (menoh_model_handle)
-    rb_ensure(build_model, (VALUE)&build_model_arg, model_builder_free, (VALUE)model_builder);
+  rb_ensure(build_model, (VALUE)&build_model_arg, model_builder_free, (VALUE)model_builder);
 
   return Qnil;
 }

--- a/ext/menoh_native/menoh_ruby.c
+++ b/ext/menoh_native/menoh_ruby.c
@@ -86,11 +86,6 @@ static void wrap_model_free(menohModel *p) {
     if (p->variable_profile_table)
       menoh_delete_variable_profile_table(p->variable_profile_table);
     if (p->model) menoh_delete_model(p->model);
-    if (p->input_buffs) {
-      for (int32_t i = 0; i < p->input_layer_num; i++) {
-        ruby_xfree(p->input_buffs[i]);
-      }
-    }
     ruby_xfree(p->input_buffs);
     ruby_xfree(p->output_buffs);
     ruby_xfree(p);
@@ -178,6 +173,7 @@ static VALUE vpt_builder_free(VALUE arg) {
 struct build_model_arg {
   VALUE self;
   VALUE vinput_layers;
+  VALUE voutput_layers;
   VALUE vbackend;
   menoh_model_data_handle model_data;
   menoh_model_builder_handle model_builder;
@@ -192,15 +188,23 @@ static VALUE build_model(VALUE arg) {
   struct build_model_arg *arg2 = (struct build_model_arg*)arg;
   VALUE self = arg2->self;
   VALUE vinput_layers = arg2->vinput_layers;
+  VALUE voutput_layers = arg2->voutput_layers;
   VALUE vbackend = arg2->vbackend;
   menoh_model_data_handle model_data = arg2->model_data;
   menoh_model_builder_handle model_builder = arg2->model_builder;
+
+  // build model
+  menoh_model_handle model;
+  ERROR_CHECK(menoh_build_model(
+                  model_builder, model_data,
+                  StringValueCStr(vbackend), "", &model),
+              rb_eStandardError);
 
   // attach input buffer to model builder
   int32_t input_layer_num =
       NUM2INT(rb_funcall(vinput_layers, id_length, 0));
   getModel(self)->input_buffs =
-      (float **)ruby_xmalloc(sizeof(float **) * input_layer_num);
+      (float **)ruby_xmalloc(sizeof(float *) * input_layer_num);
   for (int32_t i = 0; i < input_layer_num; i++) {
     VALUE vinput_layer = rb_ary_entry(vinput_layers, i);
     VALUE vname =
@@ -215,20 +219,29 @@ static VALUE build_model(VALUE arg) {
     for (int32_t j = 0; j < dims_length; j++)
       buffer_length *= NUM2INT(rb_ary_entry(vdims, j));
 
-    float *input_buff = (float *)ruby_xmalloc(sizeof(float) * buffer_length);
+    float *input_buff;
+    ERROR_CHECK(menoh_model_get_variable_buffer_handle(
+                    model, StringValueCStr(vname),
+                    (void **)&input_buff),
+                rb_eStandardError);
     getModel(self)->input_buffs[i] = input_buff;
-    ERROR_CHECK(
-        menoh_model_builder_attach_external_buffer(
-            model_builder, StringValueCStr(vname), input_buff),
-        rb_eStandardError);
   }
 
-  // build model
-  menoh_model_handle model;
-  ERROR_CHECK(menoh_build_model(
-                  model_builder, model_data,
-                  StringValueCStr(vbackend), "", &model),
-              rb_eStandardError);
+  // attach output buffer to model
+  int32_t output_layer_num =
+      NUM2INT(rb_funcall(voutput_layers, id_length, 0));
+  getModel(self)->output_buffs =
+      (float **)ruby_xmalloc(sizeof(float *) * output_layer_num);
+  for (int32_t i = 0; i < output_layer_num; i++) {
+    VALUE voutput_layer = rb_ary_entry(voutput_layers, i);
+    float *output_buff;
+    ERROR_CHECK(menoh_model_get_variable_buffer_handle(
+                    model, StringValueCStr(voutput_layer),
+                    (void **)&output_buff),
+                rb_eStandardError);
+    getModel(self)->output_buffs[i] = output_buff;
+  }
+
   return (VALUE)model;
 }
 
@@ -278,6 +291,7 @@ static VALUE wrap_model_init(VALUE self, VALUE vonnx, VALUE option) {
   struct build_model_arg build_model_arg = {
     .self = self,
     .vinput_layers = vinput_layers,
+    .voutput_layers = voutput_layers,
     .vbackend = vbackend,
     .model_data = model_data,
     .model_builder = model_builder
@@ -312,19 +326,6 @@ static VALUE wrap_model_run(VALUE self, VALUE dataset) {
       getModel(self)->input_buffs[i][j] =
           (float)(NUM2DBL(rb_ary_entry(data, j)));
     }
-  }
-
-  // attach output buffer to model
-  getModel(self)->output_buffs =
-      (float **)ruby_xmalloc(sizeof(float *) * output_layer_num);
-  for (int32_t i = 0; i < output_layer_num; i++) {
-    VALUE voutput_layer = rb_ary_entry(voutput_layers, i);
-    float *output_buff;
-    ERROR_CHECK(menoh_model_get_variable_buffer_handle(
-                    getModel(self)->model, StringValueCStr(voutput_layer),
-                    (void **)&output_buff),
-                rb_eStandardError);
-    getModel(self)->output_buffs[i] = output_buff;
   }
 
   // run model


### PR DESCRIPTION
* Use input buffer allocated by Menoh itself instead of using `menoh_model_builder_attach_external_buffer` for simplicity.
* Fixes memory leak of output_buffs when `Menoh::MenohModel#run` is called multiple time.
