### PR TITLE
add -std= option in extconf.rb

### DIFF
--- a/ext/menoh_native/extconf.rb
+++ b/ext/menoh_native/extconf.rb
@@ -1,5 +1,15 @@
 require 'mkmf'
 
+if try_cflags '-std=gnu11'
+  $CFLAGS += " -std=gnu11"
+elsif try_cflags '-std=c11'
+  $CFLAGS += " -std=c11"
+elsif try_cflags '-std=gnu99'
+  $CFLAGS += " -std=gnu99"
+elsif try_cflags '-std=c99'
+  $CFLAGS += " -std=c99"
+end
+
 if pkg_config("menoh")
   create_makefile('menoh/menoh_native')
 end


### PR DESCRIPTION
This is because old GCC uses -std=gnu90 as a default.
In particular, Travis-CI Trusty environment uses such GCC (GCC 4.8.4).