### PR TITLE
Replace URL and variable name for VGG16 example

### DIFF
--- a/example/example_vgg16.rb
+++ b/example/example_vgg16.rb
@@ -12,7 +12,7 @@ def download_file(url, output)
     end
   end
 end
-download_file('https://www.dropbox.com/s/bjfn9kehukpbmcm/VGG16.onnx?dl=1', './data/VGG16.onnx')
+download_file('https://preferredjp.box.com/shared/static/o2xip23e3f0knwc5ve78oderuglkf2wt.onnx', './data/VGG16.onnx')
 download_file('https://raw.githubusercontent.com/HoldenCaulfieldRye/caffe/master/data/ilsvrc12/synset_words.txt', './data/synset_words.txt')
 download_file('https://upload.wikimedia.org/wikipedia/commons/5/54/Light_sussex_hen.jpg', './data/Light_sussex_hen.jpg')
 download_file('https://upload.wikimedia.org/wikipedia/commons/f/fd/FoS20162016_0625_151036AA_%2827826100631%29.jpg', './data/honda_nsx.jpg')
@@ -32,9 +32,9 @@ input_shape = {
 onnx_obj = Menoh::Menoh.new './data/VGG16.onnx'
 
 # onnx variable name
-CONV1_1_IN_NAME = '140326425860192'.freeze
-FC6_OUT_NAME = '140326200777584'.freeze
-SOFTMAX_OUT_NAME = '140326200803680'.freeze
+CONV1_1_IN_NAME = 'Input_0'.freeze
+FC6_OUT_NAME = 'Gemm_0'.freeze
+SOFTMAX_OUT_NAME = 'Softmax_0'.freeze
 
 # model options for model
 model_opt = {

--- a/example/example_vgg16.rb
+++ b/example/example_vgg16.rb
@@ -28,7 +28,7 @@ input_shape = {
   width: 224,
   height: 224
 }
-rbg_offset = {
+rgb_offset = {
   R: 123.68,
   G: 116.779,
   B: 103.939
@@ -70,7 +70,7 @@ image_set = [
       image = image.resize_to_fill(input_shape[:width], input_shape[:height])
       'RGB'.split('').map do |color|
         image.export_pixels(0, 0, image.columns, image.rows, color).map do |pix|
-          pix / 256 - rbg_offset[color.to_sym]
+          pix / 256 - rgb_offset[color.to_sym]
         end
       end.flatten
     end.flatten

--- a/example/example_vgg16.rb
+++ b/example/example_vgg16.rb
@@ -62,7 +62,7 @@ image_set = [
     data: image_list.map do |image_filepath|
       image = Magick::Image.read(image_filepath).first
       image = image.resize_to_fill(input_shape[:width], input_shape[:height])
-      'BGR'.split('').map do |color|
+      'RGB'.split('').map do |color|
         image.export_pixels(0, 0, image.columns, image.rows, color).map { |pix| pix / 256 }
       end.flatten
     end.flatten

--- a/example/example_vgg16.rb
+++ b/example/example_vgg16.rb
@@ -5,6 +5,7 @@ require 'menoh'
 # download dependencies
 def download_file(url, output)
   return if File.exist? output
+
   puts "downloading... #{url}"
   File.open(output, 'wb') do |f_output|
     open(url, 'rb') do |f_input|
@@ -27,6 +28,11 @@ input_shape = {
   width: 224,
   height: 224
 }
+rbg_offset = {
+  R: 123.68,
+  G: 116.779,
+  B: 103.939
+}
 
 # load ONNX file
 onnx_obj = Menoh::Menoh.new './data/VGG16.onnx'
@@ -46,7 +52,7 @@ model_opt = {
         image_list.length,
         input_shape[:channel_num],
         input_shape[:height],
-        input_shape[:width],
+        input_shape[:width]
       ]
     }
   ],
@@ -63,7 +69,9 @@ image_set = [
       image = Magick::Image.read(image_filepath).first
       image = image.resize_to_fill(input_shape[:width], input_shape[:height])
       'RGB'.split('').map do |color|
-        image.export_pixels(0, 0, image.columns, image.rows, color).map { |pix| pix / 256 }
+        image.export_pixels(0, 0, image.columns, image.rows, color).map do |pix|
+          pix / 256 - rbg_offset[color.to_sym]
+        end
       end.flatten
     end.flatten
   }


### PR DESCRIPTION
This PR makes the VGG16 example to follow [Menoh's example](https://github.com/pfnet-research/menoh/blob/master/example/vgg16_example_in_cpp.cpp).
The difference is just to be replacing URL and variable name.