### PR TITLE
experimental Numo support

### DIFF
--- a/menoh.gemspec
+++ b/menoh.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rake-compiler'
+  spec.add_development_dependency 'numo-narray'
 end

--- a/test/menoh_test.rb
+++ b/test/menoh_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'numo/narray'
 
 MNIST_ONNX_FILE = 'example/data/mnist.onnx'.freeze
 MNIST_IN_NAME = '139900320569040'.freeze
@@ -36,6 +37,36 @@ class MenohTest < Minitest::Test
       assert_instance_of(Array, inferenced_results)
       assert_equal(MNIST_OUT_NAME, inferenced_results.first[:name])
       assert_equal(batch_size, inferenced_results.first[:data].length)
+    end
+  end
+
+  def test_menoh_basic_function_numo
+    onnx = Menoh::Menoh.new(MNIST_ONNX_FILE)
+    assert_instance_of(Menoh::Menoh, onnx)
+    batch_size = 3
+    model_opt = {
+      backend: 'mkldnn',
+      input_layers: [
+        {
+          name: MNIST_IN_NAME,
+          dims: [batch_size, 1, 28, 28]
+        }
+      ],
+      output_layers: [MNIST_OUT_NAME]
+    }
+    model = onnx.make_model(model_opt)
+    assert_instance_of(Menoh::MenohModel, model)
+    10.times do
+      imageset = [
+        {
+          name: MNIST_IN_NAME,
+          data: Numo::SFloat.zeros(batch_size, 1, 28, 28)
+        }
+      ]
+      inferenced_results = model.run_numo imageset
+      assert_instance_of(Hash, inferenced_results)
+      assert_instance_of(Numo::SFloat, inferenced_results[MNIST_OUT_NAME])
+      assert_equal([batch_size, 10], inferenced_results[MNIST_OUT_NAME].shape)
     end
   end
 


### PR DESCRIPTION
This PR is based on #26.

The performance is suboptimal due to the conversion via `String`. This can be improved by copying memory directly using `na_get_pointer` etc.