### PR TITLE
Fix versions of dependencies for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,19 +21,23 @@ RUN apt-get update && apt-get install -y \
   rm -rf /var/lib/apt/lists/*
 
 # MKL-DNN
+ENV MKLDNN_VERSION v0.17.4
 RUN mkdir /opt/mkl-dnn
 WORKDIR /opt/mkl-dnn
 RUN git clone https://github.com/01org/mkl-dnn.git && \
-    cd mkl-dnn/scripts && bash ./prepare_mkl.sh && cd .. && \
+    cd mkl-dnn && git checkout -b ${MKLDNN_VERSION} refs/tags/${MKLDNN_VERSION} && \
+    cd ./scripts && bash ./prepare_mkl.sh && cd .. && \
     sed -i 's/add_subdirectory(examples)//g' CMakeLists.txt && \
     sed -i 's/add_subdirectory(tests)//g' CMakeLists.txt && \
     mkdir -p build && cd build && cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX .. && make && \
     make install
 
 # Menoh
+ENV MENOH_VERSION v1.1.1
 WORKDIR /opt/
 RUN git clone https://github.com/pfnet-research/menoh.git && \
     cd menoh && \
+    git checkout -b ${MENOH_VERSION} refs/tags/${MENOH_VERSION} && \
     sed -i 's/add_subdirectory(example)//g' CMakeLists.txt && \
     sed -i 's/add_subdirectory(test)//g' CMakeLists.txt && \
     mkdir build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
   rm -rf /var/lib/apt/lists/*
 
 # MKL-DNN
-ENV MKLDNN_VERSION v0.17.4
+ENV MKLDNN_VERSION v0.18.1
 RUN mkdir /opt/mkl-dnn
 WORKDIR /opt/mkl-dnn
 RUN git clone https://github.com/01org/mkl-dnn.git && \

--- a/Dockerfile.pkg
+++ b/Dockerfile.pkg
@@ -1,0 +1,38 @@
+FROM ubuntu:xenial-20180228
+
+LABEL maintainer "Kunihiko Miyoshi <miyoshik@preferred.jp>"
+LABEL OBJECT="Menoh Ruby Extension Reference Environment"
+
+ENV INSTALL_PREFIX /usr/local
+ENV LD_LIBRARY_PATH ${INSTALL_PREFIX}/lib
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  git \
+  gcc \
+  g++ \
+  cmake \
+  cmake-data \
+  libopencv-dev \
+  protobuf-compiler \
+  libprotobuf-dev \
+  ruby-dev \
+  ruby-rmagick \
+  ruby-bundler
+
+RUN mkdir -p /opt
+# MKL-DNN & Menoh
+WORKDIR /opt
+RUN curl -LO https://github.com/pfnet-research/menoh/releases/download/v1.1.0/ubuntu1604_mkl-dnn_0.16-1_amd64.deb
+RUN curl -LO https://github.com/pfnet-research/menoh/releases/download/v1.1.0/ubuntu1604_menoh_1.1.0-1_amd64.deb
+RUN curl -LO https://github.com/pfnet-research/menoh/releases/download/v1.1.0/ubuntu1604_menoh-dev_1.1.0-1_amd64.deb
+RUN apt update
+RUN dpkg -i --force-depends *.deb
+RUN rm -rf /var/lib/apt/lists/*
+
+# menoh-ruby
+RUN gem install rake-compiler
+RUN mkdir /opt/menoh-ruby
+ADD . /opt/menoh-ruby
+WORKDIR /opt/menoh-ruby
+RUN rake && rake install


### PR DESCRIPTION
This PR fixes the versions of dependencies for `Dockerfile`, because of [MKL-DNN](https://github.com/intel/mkl-dnn)'s destructive change planned on `v1.0.0`.

In addition, I added `Dockerfile.pkg` which depends on prebuilt packages distributed on [Menoh's release page](https://github.com/pfnet-research/menoh/releases).